### PR TITLE
Remove check for Hello World

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -12,7 +12,6 @@ class ExampleTest extends TestCase {
         $response = $this->call('GET', '/');
 
         $this->assertResponseOk();
-        $this->assertEquals('Hello World', $response->getContent());
     }
 
 }


### PR DESCRIPTION
There is no "Hello World" page on the default install, just displays "Lumen." So we should just be able to assert that the response is OK to get green on a default install, similar the default test on laravel/laravel.