### PR TITLE
Set default storage path

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,8 @@ require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Laravel\Lumen\Application;
 
+$app->useStoragePath(realpath(__DIR__.'/../storage/'));
+
 // $app->withFacades();
 
 // $app->withEloquent();


### PR DESCRIPTION
Fix for running with PHP built-in web server.

The log file path should be `storage/logs/lumen.log`, but `public/storage/logs/lumen.log` is used as follow:

```sh
$ php artisan serve
Lumen development server started on http://localhost:8000/
[Wed Apr 22 17:59:41 2015] PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'The stream or file "/Users/meye/lumen/public/storage/logs/lumen.log" could not be opened: failed to open stream: No such file or directory' in /Users/meye/lumen/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php:84
Stack trace:
#0 /Users/meye/lumen/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php(37): Monolog\Handler\StreamHandler->write(Array)
#1 /Users/meye/lumen/vendor/monolog/monolog/src/Monolog/Logger.php(265): Monolog\Handler\AbstractProcessingHandler->handle(Array)
#2 /Users/meye/lumen/vendor/monolog/monolog/src/Monolog/Logger.php(543): Monolog\Logger->addRecord(400, 'exception 'Unex...', Array)
#3 /Users/meye/lumen/vendor/laravel/lumen-framework/src/Exceptions/Handler.php(30): Monolog\Logger->error('exception 'Unex...')
#4 /Users/meye/lumen/app/Exceptions/Handler.php(27): Laravel\Lumen\Exceptions\Handler->report(Object(UnexpectedValu in /Users/meye/lumen/vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php on line 84
```