### PR TITLE
Fix abstract Job to fit the doc

### DIFF
--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -3,12 +3,8 @@
 namespace App\Jobs;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Bus\SelfHandling;
-use Illuminate\Contracts\Queue\ShouldQueue;
 
-abstract class Job implements SelfHandling, ShouldQueue
+abstract class Job
 {
     /*
     |--------------------------------------------------------------------------
@@ -21,5 +17,5 @@ abstract class Job implements SelfHandling, ShouldQueue
     |
     */
 
-    use InteractsWithQueue, Queueable, SerializesModels;
+    use Queueable;
 }


### PR DESCRIPTION
Queue example from the [document](http://lumen.laravel.com/docs/queues) throws error, and it seems the default abstract job class does too much.

discussion: https://laracasts.com/discuss/channels/lumen/queue-example-throws-error