### PR TITLE
Trailing slashes directory condition

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,6 +6,7 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes...
+    RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 
     # Handle Front Controller...

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,7 +5,7 @@
 
     RewriteEngine On
 
-    # Redirect Trailing Slashes...
+    # Redirect Trailing Slashes If Not A Folder...
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteRule ^(.*)/$ /$1 [L,R=301]
 


### PR DESCRIPTION
Add rewrite condition to the trailing slashes rewrite due to a redirect loop occurring when making a request to a public directory.