### PR TITLE
added required ext from lumen doc

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,10 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/lumen-framework": "5.1.*",
-        "vlucas/phpdotenv": "~1.0"
+        "vlucas/phpdotenv": "~1.0",
+        "ext-openssl": "*",
+        "ext-mbstring": "*",
+        "ext-tokenizer": "^0.1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
in
http://lumen.laravel.com/docs/installation#installation 
server requirements:
PHP >= 5.5.9
OpenSSL PHP Extension
Mbstring PHP Extension
Tokenizer PHP Extension
but composer.json not have it.