### PR TITLE
[5.1] Revert 3087f15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,2 @@
 /vendor
-/storage/logs
-/storage/framework/cache
 .env
-.env.example


### PR DESCRIPTION
Reverts laravel/lumen#43

These storage directories already have .gitignore files and I can't see why .env.example should be ignored.