### PR TITLE
Removing return inside ExceptionHandler

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,7 +24,7 @@ class Handler extends ExceptionHandler {
      */
     public function report(Exception $e)
     {
-        return parent::report($e);
+        parent::report($e);
     }
 
     /**


### PR DESCRIPTION
Had a "chat" with Taylor, according to him this return is not needed. ( hoping to get my first contribution to Lumen <3 )