### PR TITLE
Removing return inside ExceptionHandler

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -24,7 +24,7 @@ class Handler extends ExceptionHandler {
      */
     public function report(Exception $e)
     {
-        return parent::report($e);
+        parent::report($e);
     }
 
     /**


### PR DESCRIPTION
This return is not needed. ( According to a "chat" with Taylor )