### PR TITLE
Make sure we work on php 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/lumen-framework": "5.2.*",
+        "symfony/polyfill-php56": "~1.0",
         "vlucas/phpdotenv": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
In the interest of keeping lumen/framework light, I think this is the correct place to put it. If people want their apps to be 5.6+ only, they can simply remove this dependency from their applications freely.