### PR TITLE
'API' isn't a supported driver

### DIFF
--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -30,7 +30,7 @@ class AuthServiceProvider extends ServiceProvider
         // should return either a User instance or null. You're free to obtain
         // the User instance via an API token or any other method necessary.
 
-        $this->app['auth']->viaRequest('api', function ($request) {
+        $this->app['auth']->viaRequest('token', function ($request) {
             if ($request->input('api_token')) {
                 return User::where('api_token', $request->input('api_token'))->first();
             }


### PR DESCRIPTION
The AuthServiceProvider is using `api` but this isn't a "supported" driver and is quite confusing for people upgrading as this isn't documented anywhere in the lumen docs. It makes sense to keep to the defined terminology, as shown in `lumen-framework`, if nothing is going to be documented around the feature.

This resolves https://github.com/laravel/lumen-framework/issues/319 which was closed without any consideration...

This PR ties hand-in-hand with https://github.com/laravel/lumen-framework/pull/358