### PR TITLE
[5.2] Pass parameters to assertEquals in correct order

### DIFF
--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -14,7 +14,7 @@ class ExampleTest extends TestCase
         $this->get('/');
 
         $this->assertEquals(
-            $this->response->getContent(), $this->app->version()
+            $this->app->version(), $this->response->getContent()
         );
     }
 }


### PR DESCRIPTION
In assertEquals() method the parameter  `$this->app->version()` 
should be exptected and paramter `$this->response->getContent()` 
should be actual.