### PR TITLE
adding post root package install composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
             "tests/",
             "database/"
         ]
+    },
+    "scripts": {
+        "post-root-package-install": [
+            "php -r \"copy('.env.example', '.env');\""
+        ]
     }
 }


### PR DESCRIPTION
I didn't see that this PR was rejected. I noticed this difference between the laravel installer and the lumen installer. 