### PR TITLE
Requiring Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "phpunit/phpunit": "~4.0"
+        "phpunit/phpunit": "~4.0",
+        "mockery/mockery": "~0.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
On a fresh installation, tests that call `$this->expectsJobs([*]);` throw a `Class "Mockery\Mockery" not found` exception. Requiring Mockery fixes this!