### PR TITLE
Added minimum-stability and prefer-stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,7 @@
         "post-root-package-install": [
             "php -r \"copy('.env.example', '.env');\""
         ]
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
When I try to run "composer update" for the first time, composer shows the following error:

```
Problem 1
    - The requested package laravel/lumen-framework 5.3.* is satisfiable by laravel/lumen-framework[5.3.x-dev] but these conflict with your requirements or minimum-stability.
```