### PR TITLE
Handle authorization header

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -13,4 +13,8 @@
     RewriteCond %{REQUEST_FILENAME} !-d
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteRule ^ index.php [L]
+
+    # Handle Authorization Header
+    RewriteCond %{HTTP:Authorization} .
+    RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 </IfModule>


### PR DESCRIPTION
Copied from Laravel. It's necessary for token-based authentication because Apache strips the Authorization header.

See also: https://github.com/laravel/laravel/pull/3636