### PR TITLE
Added possibility for rate limiting requests

### DIFF
--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,0 +1,116 @@
+<?php
+namespace App\Http\Middleware;
+use Closure;
+use Carbon\Carbon;
+use Illuminate\Cache\RateLimiter;
+use Symfony\Component\HttpFoundation\Response;
+class ThrottleRequests
+{
+    /**
+     * The rate limiter instance.
+     *
+     * @var \Illuminate\Cache\RateLimiter
+     */
+    protected $limiter;
+
+    /**
+     * Create a new request throttler.
+     *
+     * @param  \Illuminate\Cache\RateLimiter $limiter
+     */
+    public function __construct(RateLimiter $limiter)
+    {
+        $this->limiter = $limiter;
+    }
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int  $maxAttempts
+     * @param  float|int  $decayMinutes
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $maxAttempts = 60, $decayMinutes = 1)
+    {
+        $key = $this->resolveRequestSignature($request);
+        if ($this->limiter->tooManyAttempts($key, $maxAttempts, $decayMinutes)) {
+            return $this->buildResponse($key, $maxAttempts);
+        }
+        $this->limiter->hit($key, $decayMinutes);
+        $response = $next($request);
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts)
+        );
+    }
+    /**
+     * Resolve request signature.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return string
+     */
+    protected function resolveRequestSignature($request)
+    {
+        return sha1(
+            $request->method() .
+            '|' . $request->server('SERVER_NAME') .
+            '|' . $request->path() .
+            '|' . $request->ip()
+        );
+    }
+    /**
+     * Create a 'too many attempts' response.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function buildResponse($key, $maxAttempts)
+    {
+        $response = new Response('Too Many Attempts.', 429);
+        $retryAfter = $this->limiter->availableIn($key);
+        return $this->addHeaders(
+            $response, $maxAttempts,
+            $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
+            $retryAfter
+        );
+    }
+    /**
+     * Add the limit header information to the given response.
+     *
+     * @param  \Symfony\Component\HttpFoundation\Response  $response
+     * @param  int  $maxAttempts
+     * @param  int  $remainingAttempts
+     * @param  int|null  $retryAfter
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        $headers = [
+            'X-RateLimit-Limit' => $maxAttempts,
+            'X-RateLimit-Remaining' => $remainingAttempts,
+        ];
+        if (! is_null($retryAfter)) {
+            $headers['Retry-After'] = $retryAfter;
+            $headers['X-RateLimit-Reset'] = Carbon::now()->getTimestamp() + $retryAfter;
+        }
+        $response->headers->add($headers);
+        return $response;
+    }
+    /**
+     * Calculate the number of remaining attempts.
+     *
+     * @param  string  $key
+     * @param  int  $maxAttempts
+     * @param  int|null  $retryAfter
+     * @return int
+     */
+    protected function calculateRemainingAttempts($key, $maxAttempts, $retryAfter = null)
+    {
+        if (is_null($retryAfter)) {
+            return $this->limiter->retriesLeft($key, $maxAttempts);
+        }
+        return 0;
+    }
+}

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -59,9 +59,9 @@ class ThrottleRequests
     protected function resolveRequestSignature($request)
     {
         return sha1(
-            $request->method() .
-            '|'.$request->server('SERVER_NAME') .
-            '|'.$request->path() .
+            $request->method().
+            '|'.$request->server('SERVER_NAME').
+            '|'.$request->path().
             '|'.$request->ip()
         );
     }
@@ -125,5 +125,4 @@ class ThrottleRequests
 
         return 0;
     }
-
 }

--- a/app/Http/Middleware/ThrottleRequests.php
+++ b/app/Http/Middleware/ThrottleRequests.php
@@ -1,9 +1,12 @@
 <?php
+
 namespace App\Http\Middleware;
+
 use Closure;
 use Carbon\Carbon;
 use Illuminate\Cache\RateLimiter;
 use Symfony\Component\HttpFoundation\Response;
+
 class ThrottleRequests
 {
     /**
@@ -22,6 +25,7 @@ class ThrottleRequests
     {
         $this->limiter = $limiter;
     }
+
     /**
      * Handle an incoming request.
      *
@@ -39,11 +43,13 @@ class ThrottleRequests
         }
         $this->limiter->hit($key, $decayMinutes);
         $response = $next($request);
+
         return $this->addHeaders(
             $response, $maxAttempts,
             $this->calculateRemainingAttempts($key, $maxAttempts)
         );
     }
+
     /**
      * Resolve request signature.
      *
@@ -54,11 +60,12 @@ class ThrottleRequests
     {
         return sha1(
             $request->method() .
-            '|' . $request->server('SERVER_NAME') .
-            '|' . $request->path() .
-            '|' . $request->ip()
+            '|'.$request->server('SERVER_NAME') .
+            '|'.$request->path() .
+            '|'.$request->ip()
         );
     }
+
     /**
      * Create a 'too many attempts' response.
      *
@@ -70,12 +77,14 @@ class ThrottleRequests
     {
         $response = new Response('Too Many Attempts.', 429);
         $retryAfter = $this->limiter->availableIn($key);
+
         return $this->addHeaders(
             $response, $maxAttempts,
             $this->calculateRemainingAttempts($key, $maxAttempts, $retryAfter),
             $retryAfter
         );
     }
+
     /**
      * Add the limit header information to the given response.
      *
@@ -96,8 +105,10 @@ class ThrottleRequests
             $headers['X-RateLimit-Reset'] = Carbon::now()->getTimestamp() + $retryAfter;
         }
         $response->headers->add($headers);
+
         return $response;
     }
+
     /**
      * Calculate the number of remaining attempts.
      *
@@ -111,6 +122,8 @@ class ThrottleRequests
         if (is_null($retryAfter)) {
             return $this->limiter->retriesLeft($key, $maxAttempts);
         }
+
         return 0;
     }
+
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -67,9 +67,9 @@ $app->singleton(
 //     'auth' => App\Http\Middleware\Authenticate::class,
 // ]);
 
-//$app->routeMiddleware([
-//    'throttle' => App\Http\Middleware\ThrottleRequests::class,
-//]);
+// $app->routeMiddleware([
+//     'throttle' => App\Http\Middleware\ThrottleRequests::class,
+// ]);
 
 /*
 |--------------------------------------------------------------------------

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -67,6 +67,10 @@ $app->singleton(
 //     'auth' => App\Http\Middleware\Authenticate::class,
 // ]);
 
+//$app->routeMiddleware([
+//    'throttle' => App\Http\Middleware\ThrottleRequests::class,
+//]);
+
 /*
 |--------------------------------------------------------------------------
 | Register Service Providers


### PR DESCRIPTION
I think since Lumen is used a lot for API's it would be nice to have the Laravel throttle middleware available. Only the resolveRequestSignature method had to be changed.