### PR TITLE
Fix fresh artisan error b/c of memcached default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,5 +10,5 @@ DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
 
-CACHE_DRIVER=memcached
+CACHE_DRIVER=file
 QUEUE_DRIVER=sync


### PR DESCRIPTION
a fresh artisan call fails b/c of default memcached setting in .env file.
```
 ✗ php artisan 

                                                           
  [Symfony\Component\Debug\Exception\FatalThrowableError]  
  Class 'Memcached' not found 
```

also found here: http://stackoverflow.com/questions/42024806/class-memcached-not-found-lumen-5-4

switchin this to file cache should be a better starting point