### PR TITLE
[5.5] Update mockery/mockery in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",
-        "phpunit/phpunit": "~6.0",
-        "mockery/mockery": "~0.9"
+        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "~6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated `mockery/mockery` to `~1.0` to match Laravel [composer file](https://github.com/laravel/laravel/blob/master/composer.json#L16).