### PR TITLE
[5.6] Updating composer.json to allow for seeds and factories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,17 @@
         "mockery/mockery": "~1.0"
     },
     "autoload": {
+        "classmap": [
+            "database/seeds",
+            "database/factories"
+        ],
         "psr-4": {
             "App\\": "app/"
         }
     },
     "autoload-dev": {
         "classmap": [
-            "tests/",
-            "database/"
+            "tests/"
         ]
     },
     "scripts": {


### PR DESCRIPTION
# Type
Bugfix/Feature Request

## Use Case
I'd like to be able to use my database seeds and factories to seed my environment after doing a `composer install --no-dev` in my QA environment. 

### Current behavior
When I run:

```sh 
composer install --no-dev --optimize-autoloader
php artisan migrate:refresh --seed
```

I get `Class DatabaseSeeder does not exist`.

### Ideal behavior
I should not get this error and I should be able to seed successfully.

### Notes
While this may not be a "required" change, and I can just change it in my own `composer.json` manually. I'm uncertain as to why `laravel/laravel` has a slightly different `composer.json` in this regard. If the idea was to be as a "tight" and  "performant" as possible in Lumen, I can maybe see that autoloading a few less classes may save some space, but I feel like not being able to run database seeds consistently in a QA environment is a bit larger of a problem.