### PR TITLE
[5.6] Remove deprecated syntaxCheck parameter.

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Application Test Suite">
             <directory suffix="Test.php">./tests</directory>


### PR DESCRIPTION
Currently generating the following warning:
```
PHPUnit 7.2.6 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 11:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```