### PR TITLE
Add DB_CHARSET and DB_COLLATION to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ DB_PORT=3306
 DB_DATABASE=homestead
 DB_USERNAME=homestead
 DB_PASSWORD=secret
+DB_CHARSET=utf8mb4
+DB_COLLATION=utf8mb4_unicode_ci
 
 CACHE_DRIVER=file
 QUEUE_CONNECTION=sync


### PR DESCRIPTION
I spent quite some time with the exception "Unknown character set: 'utf8mb4'", when hooking up Lumen to an older mysql installation, so I thought it might be a good idea to add it to the `.env.example`.