### PR TITLE
[5.8] Encourage PHPUnit 8 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     },
     "require-dev": {
         "fzaninotto/faker": "^1.4",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "mockery/mockery": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
**This PR needs to wait until laravel/lumen-framework has PHPUnit 8 support: https://github.com/laravel/lumen-framework/pull/872**

Encourage people to use PHPUnit 8.