### PR TITLE
[5.7] Handler::render might return a JsonResponse as well

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -41,7 +41,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Exception  $exception
-     * @return \Illuminate\Http\Response
+     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
      */
     public function render($request, Exception $exception)
     {


### PR DESCRIPTION
When working with APIs, a JsonResponse is returned, for example, when dealing with validations.