### PR TITLE
Return a function from routes file

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -94,7 +94,8 @@ $app->singleton(
 $app->router->group([
     'namespace' => 'App\Http\Controllers',
 ], function ($router) {
-    require __DIR__.'/../routes/web.php';
+    $routes = require __DIR__.'/../routes/web.php';
+    $routes($router);
 });
 
 return $app;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,7 @@
 <?php
 
+use Laravel\Lumen\Routing\Router;
+
 /*
 |--------------------------------------------------------------------------
 | Application Routes
@@ -10,7 +12,8 @@
 | and give it the Closure to call when that URI is requested.
 |
 */
-
-$router->get('/', function () use ($router) {
-    return $router->app->version();
-});
+return function (Router $router) {
+    $router->get('/', function () use ($router) {
+        return $router->app->version();
+    });
+};


### PR DESCRIPTION
In order to offer better code completude on the main routes file (`web.php`) in all major editors, we need to make the routes file return a function so we can type hint the `$router` parameter on that same file. This also avoids some inspection warnings methods like `->get`, `->post`, etc. not being found on the `$router` variable (phpstorm). 

The performance overhead is totally negligible while the benefit of code completion from IDEs on the router object can save some time to a lot of developers, specially those who are starting their path into laravel/lumen.