### PR TITLE
[5.8] No need to require phpdotenv anymore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.1.3",
-        "laravel/lumen-framework": "5.8.*",
-        "vlucas/phpdotenv": "^3.3"
+        "laravel/lumen-framework": "5.8.*"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.4",


### PR DESCRIPTION
New Lumen apps need not require this anymore since the lumen framework will have it.