### PR TITLE
[6.x] Allowing optional use of yml/yaml file extensions in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,5 @@ trim_trailing_whitespace = true
 [*.md]
 trim_trailing_whitespace = false
 
-[*.yml]
+[*.{yml,yaml}]
 indent_size = 2


### PR DESCRIPTION
Moved changes from Laravel repository - https://github.com/laravel/laravel/pull/5090