### PR TITLE
[6.x] Ignore PHPUnit result cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Homestead.json
 Homestead.yaml
 .env
+.phpunit.result.cache


### PR DESCRIPTION
After upgrading an older lumen application, I noticed that phpunit result cache was not ignored.

I had accidentally committed this file, but I hope others didn't need to follow the same path I did ¯\_(ツ)_/¯