### PR TITLE
use FQCNs

### DIFF
--- a/app/Listeners/ExampleListener.php
+++ b/app/Listeners/ExampleListener.php
@@ -21,7 +21,7 @@ class ExampleListener
     /**
      * Handle the event.
      *
-     * @param  ExampleEvent  $event
+     * @param  \App\Events\ExampleEvent  $event
      * @return void
      */
     public function handle(ExampleEvent $event)

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,8 +12,8 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\ExampleEvent' => [
-            'App\Listeners\ExampleListener',
+        \App\Events\ExampleEvent::class => [
+            \App\Listeners\ExampleListener::class,
         ],
     ];
 }


### PR DESCRIPTION
This PR brings the `::class` signature in the event service provider instead of using strings – like Laravel's event service provider.