### PR TITLE
[7.x] Move timezone setting to app bootstrap file

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -6,6 +6,8 @@ require_once __DIR__.'/../vendor/autoload.php';
     dirname(__DIR__)
 ))->bootstrap();
 
+date_default_timezone_set(env('APP_TIMEZONE', 'UTC'));
+
 /*
 |--------------------------------------------------------------------------
 | Create The Application


### PR DESCRIPTION
See https://github.com/laravel/lumen-framework/pull/1014. The reason for removing the `if` that was originally in the lumen framework code is that we now match the laravel/framework behaviour, which just reads the timezone from the app config, and always sets it.

---

Related to https://github.com/laravel/lumen-framework/pull/1014.