### PR TITLE
Fix spelling in PHPDoc (driectory)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -54,7 +54,7 @@ $app->singleton(
 |--------------------------------------------------------------------------
 |
 | Now we will register the "app" configuration file. If the file exists in
-| your configuration driectory it will be loaded; otherwise, we'll load
+| your configuration directory it will be loaded; otherwise, we'll load
 | the default version. You may register other files below as needed.
 |
 */


### PR DESCRIPTION
Changed "driectory" to "directory" within Config-Files PHPDoc block.