### PR TITLE
[7.x] Update return type of Handler::render method

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -43,7 +43,7 @@ class Handler extends ExceptionHandler
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Throwable  $exception
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+     * @return \Symfony\Component\HttpFoundation\Response
      *
      * @throws \Throwable
      */


### PR DESCRIPTION
We should type hint the base class here. Cause [parent method](https://github.com/laravel/lumen-framework/blob/7.x/src/Exceptions/Handler.php#L92) has the base class as return type.

It is also like this in `laravel/laravel` repo: https://github.com/laravel/laravel/blob/master/app/Exceptions/Handler.php#L47 PR: https://github.com/laravel/laravel/pull/5187