### PR TITLE
[8.x] Disable putenv()

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,8 @@
 
 require_once __DIR__.'/../vendor/autoload.php';
 
+Illuminate\Support\Env::disablePutenv();
+
 (new Laravel\Lumen\Bootstrap\LoadEnvironmentVariables(
     dirname(__DIR__)
 ))->bootstrap();


### PR DESCRIPTION
Add this line because of [#8191](https://github.com/laravel/framework/issues/8191#issue-64656690) occurred in php ts version, and `artisan config:cache` can not be used in lumen.