### PR TITLE
[8.x] Bumps framework dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,12 +6,12 @@
     "type": "project",
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/lumen-framework": "^8.0"
+        "laravel/lumen-framework": "^8.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
         "mockery/mockery": "^1.3.1",
-        "phpunit/phpunit": "^9.3"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request is a follow up of this https://github.com/laravel/lumen-framework/pull/1197. @driesvints This pull request assumes that the next version of "lumen-framework" is `8.3`.