### PR TITLE
[9.x] Update artisan kernel class to match Laravel

### DIFF
--- a/artisan
+++ b/artisan
@@ -28,8 +28,6 @@ $app = require __DIR__.'/bootstrap/app.php';
 |
 */
 
-$kernel = $app->make(
-    'Illuminate\Contracts\Console\Kernel'
-);
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
 
 exit($kernel->handle(new ArgvInput, new ConsoleOutput));


### PR DESCRIPTION
A minor update to the artisan kernel class to match Laravel: https://github.com/laravel/laravel/blob/9.x/artisan#L33